### PR TITLE
Replace PHP 4 constructor

### DIFF
--- a/dm_widget.php
+++ b/dm_widget.php
@@ -5,7 +5,7 @@ class DM_Widget extends WP_Widget {
     function DM_Widget() {
         $widget_ops = array('classname' => 'dm_widget', 'description' => __('Put a signup form on your WordPress Website', 'dm_widget'));
         $control_ops = array('id_base' => 'dm_widget');
-        $this->WP_Widget('dm_widget', __('dotmailer Sign-up Form', 'dm_widget'), $widget_ops, $control_ops);
+        parent::__construct('dm_widget', __('dotmailer Sign-up Form', 'dm_widget'), $widget_ops, $control_ops);
     }
 
     function widget($args, $instance) {


### PR DESCRIPTION
Removes following error in WordPress 4.5.2:

`Notice: The called constructor method for WP_Widget in DM_Widget is deprecated since version 4.3.0! Use __construct() instead.`