### PR TITLE
Wrap informative logging with a WP_DEBUG check

### DIFF
--- a/includes/class-dotdigital-wordpress-patch-manager.php
+++ b/includes/class-dotdigital-wordpress-patch-manager.php
@@ -115,7 +115,9 @@ class Dotdigital_WordPress_Patch_Manager {
 		}
 		if ( preg_match( '/class\s+(\w+)/', $contents, $matches ) ) {
 			$class_name = $namespace . $matches[1];
-			error_log( 'Extracted class name: ' . $class_name ); // Add this line for logging.
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+				error_log( 'Extracted class name: ' . $class_name ); // Add this line for logging.
+			}
 			return $class_name;
 		}
 		return null;


### PR DESCRIPTION
## What's being changed
Making a particular call to `error_log` only appear in an environment where `WP_DEBUG` and `WP_BEBUG_LOG` are defined (e.g. for development/local)

## Why it's being changed
This particular `error_log` is not providing any indication of errors but just notifying of patching. This is not useful on a production environment so we should only log this information when `WP_DEBUG` is `true` and `WP_DEBUG_LOG` is truthy.

Fixes #11

## How to review / test this change
Visit any URLs that trigger the patch note methods.